### PR TITLE
Send customConfig to Papa-parse, not only when previewing

### DIFF
--- a/package-core/src/components/Importer.tsx
+++ b/package-core/src/components/Importer.tsx
@@ -223,6 +223,7 @@ export function Importer<Row extends BaseRow>({
       content={content}
     >
       <ProgressDisplay
+        customConfig={customPapaParseConfig}
         preview={preview}
         externalPreview={externalPreview}
         fieldAssignments={fieldAssignments}

--- a/package-core/src/components/parser.ts
+++ b/package-core/src/components/parser.ts
@@ -126,14 +126,23 @@ export function parsePreview(
   });
 }
 
-export function processFile<Row extends BaseRow>(
-  file: File,
-  hasHeaders: boolean,
-  fieldAssignments: FieldAssignmentMap,
-  reportProgress: (deltaCount: number) => void,
-  callback: ParseCallback<Row>,
-  chunkSize?: number
-): Promise<void> {
+export function processFile<Row extends BaseRow>({
+  file,
+  hasHeaders,
+  fieldAssignments,
+  reportProgress,
+  callback,
+  chunkSize,
+  customConfig = {}
+}: {
+  file: File;
+  hasHeaders: boolean;
+  fieldAssignments: FieldAssignmentMap;
+  reportProgress: (deltaCount: number) => void;
+  callback: ParseCallback<Row>;
+  chunkSize?: number;
+  customConfig: CustomizablePapaParseConfig;
+}): Promise<void> {
   const fieldNames = Object.keys(fieldAssignments);
 
   // wrap synchronous errors in promise
@@ -146,6 +155,8 @@ export function processFile<Row extends BaseRow>(
     // true streaming support for local files (@todo wait for upstream fix)
     const nodeStream = new ReadableWebToNodeStream(file.stream());
     Papa.parse(nodeStream, {
+      ...customConfig,
+
       chunkSize: chunkSize || 10000,
       skipEmptyLines: true,
       error: (error) => {


### PR DESCRIPTION
The existing upstream code has an issue: the custom papa-parse configuration that is set on the Importer component (such as `delimiter` or `delimitersToGuess` are only sent to the `FormatPreview` component of `react-csv-import`. The configuration is not sent to the real `ProgressDisplay` component that does the real parsing of the file. As a result, the preview might look fine, but the actual parsing of the CSV file can fail, because it doesn't follow the same configuration. For example, if you use a `;`-separated CSV file and you have `;` inside the content of your columns, the parsing will sometimes fail. Setting the `delimiter=";"` prop on the Importer component will fix the preview, but the real actual parsing will still fail.

This pull request fixes this by sending the custom papa-parse configuration to the `ProgressDisplay` component as well. As a result, end users can set the papa-parse configuration on the `Importer` component and this configuration will actually be used (so the preview and the end result will have the same results).

Thank you.