### PR TITLE
fix ColumnDragState y value

### DIFF
--- a/src/components/ColumnDragState.tsx
+++ b/src/components/ColumnDragState.tsx
@@ -97,6 +97,9 @@ export function useColumnDragState(
   );
 
   const bindDrag = useDrag(({ first, last, event, xy, args }) => {
+    if (event) {
+      xy[1] = event.pageY;
+    }
     if (first && event) {
       event.preventDefault();
 


### PR DESCRIPTION
When the page is scrolled down, the column drag objects don't get the right y value assigned to them, so they're offset by the scrolled amount. This fixes that.