### PR TITLE
Use custom text for the next button of individual import steps

### DIFF
--- a/src/components/ImporterFrame.tsx
+++ b/src/components/ImporterFrame.tsx
@@ -12,7 +12,7 @@ export const ImporterFrame: React.FC<{
   secondaryDisabled?: boolean;
   secondaryLabel?: string;
   nextDisabled?: boolean;
-  nextLabel?: string;
+  nextLabel: string;
   error?: string | null;
   onSecondary?: () => void;
   onNext: () => void;
@@ -95,7 +95,7 @@ export const ImporterFrame: React.FC<{
           </div>
         ) : null}
         <TextButton disabled={!!nextDisabled} onClick={onNext}>
-          {nextLabel || l10n.nextButton}
+          {nextLabel}
         </TextButton>
       </div>
     </div>

--- a/src/components/fields-step/FieldsStep.tsx
+++ b/src/components/fields-step/FieldsStep.tsx
@@ -149,6 +149,7 @@ export const FieldsStep: React.FC<{
           setValidationError(l10n.requiredFieldsError);
         }
       }}
+      nextLabel={l10n.nextButton}
     >
       <ColumnDragSourceArea
         columns={columns}

--- a/src/components/file-step/FileStep.tsx
+++ b/src/components/file-step/FileStep.tsx
@@ -185,6 +185,7 @@ export const FileStep: React.FC<{
         onAccept();
       }}
       onCancel={() => setSelectedFile(null)}
+      nextLabel={l10n.nextButton}
     >
       {reportBlock || (
         <div className="CSVImporter_FileStep__mainPendingBlock">

--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -3,7 +3,6 @@
 export interface ImporterLocale {
   general: {
     goToPreviousStepTooltip: string;
-    nextButton: string;
   };
 
   fileStep: {
@@ -13,6 +12,7 @@ export interface ImporterLocale {
     getImportError: (message: string) => string;
     getDataFormatError: (message: string) => string;
     goBackButton: string;
+    nextButton: string;
 
     rawFileContentsHeading: string;
     previewImportHeading: string;
@@ -23,6 +23,7 @@ export interface ImporterLocale {
   fieldsStep: {
     stepSubtitle: string;
     requiredFieldsError: string;
+    nextButton: string;
 
     dragSourceAreaCaption: string;
     getDragSourcePageIndicator: (
@@ -60,8 +61,7 @@ export interface ImporterLocale {
 
 export const enUS: ImporterLocale = {
   general: {
-    goToPreviousStepTooltip: 'Go to previous step',
-    nextButton: 'Next'
+    goToPreviousStepTooltip: 'Go to previous step'
   },
 
   fileStep: {
@@ -72,6 +72,7 @@ export const enUS: ImporterLocale = {
     getImportError: (message) => `Import error: ${message}`,
     getDataFormatError: (message) => `Please check data formatting: ${message}`,
     goBackButton: 'Go Back',
+    nextButton: 'Choose columns',
 
     rawFileContentsHeading: 'Raw File Contents',
     previewImportHeading: 'Preview Import',
@@ -82,6 +83,7 @@ export const enUS: ImporterLocale = {
   fieldsStep: {
     stepSubtitle: 'Select Columns',
     requiredFieldsError: 'Please assign all required fields',
+    nextButton: 'Import',
 
     dragSourceAreaCaption: 'Columns to import',
     getDragSourcePageIndicator: (currentPage: number, pageCount: number) =>
@@ -119,14 +121,14 @@ export const enUS: ImporterLocale = {
 
 export const deDE: ImporterLocale = {
   general: {
-    goToPreviousStepTooltip: 'Zum vorherigen Schritt',
-    nextButton: 'Weiter'
+    goToPreviousStepTooltip: 'Zum vorherigen Schritt'
   },
 
   fileStep: {
     initialDragDropPrompt:
       'CSV-Datei auf dieses Feld ziehen, oder klicken um eine Datei auszuwählen',
     activeDragDropPrompt: 'CSV-Datei auf dieses Feld ziehen...',
+    nextButton: 'Spalten auswählen',
 
     getImportError: (message) => `Fehler beim Import: ${message}`,
     getDataFormatError: (message: string) =>
@@ -143,6 +145,7 @@ export const deDE: ImporterLocale = {
     stepSubtitle: 'Spalten auswählen',
     requiredFieldsError:
       'Bitte weise allen nicht optionalen Spalten einen Wert zu',
+    nextButton: 'Importieren',
 
     dragSourceAreaCaption: 'Zu importierende Spalte',
     getDragSourcePageIndicator: (currentPage: number, pageCount: number) =>

--- a/test/basics.test.ts
+++ b/test/basics.test.ts
@@ -149,7 +149,7 @@ describe('importer basics', () => {
     describe('with preview accepted', () => {
       beforeEach(async () => {
         const nextButton = await getDriver().findElement(
-          By.xpath('//button[text() = "Next"]')
+          By.xpath('//button[text() = "Choose columns"]')
         );
 
         await nextButton.click();
@@ -181,7 +181,7 @@ describe('importer basics', () => {
 
       it('does not allow to proceed without assignment', async () => {
         const nextButton = await getDriver().findElement(
-          By.xpath('//button[text() = "Next"]')
+          By.xpath('//button[text() = "Import"]')
         );
 
         await nextButton.click();
@@ -231,7 +231,7 @@ describe('importer basics', () => {
         describe('with confirmation to start processing', () => {
           beforeEach(async () => {
             const nextButton = await getDriver().findElement(
-              By.xpath('//button[text() = "Next"]')
+              By.xpath('//button[text() = "Import"]')
             );
 
             await nextButton.click();

--- a/test/customConfig.test.ts
+++ b/test/customConfig.test.ts
@@ -94,7 +94,7 @@ describe('importer with custom Papa Parse config', () => {
     describe('after accepting and assigning fields', () => {
       beforeEach(async () => {
         const previewNextButton = await getDriver().findElement(
-          By.xpath('//button[text() = "Next"]')
+          By.xpath('//button[text() = "Choose columns"]')
         );
 
         await previewNextButton.click();
@@ -126,7 +126,7 @@ describe('importer with custom Papa Parse config', () => {
         await assignButton.click();
 
         const fieldsNextButton = await getDriver().findElement(
-          By.xpath('//button[text() = "Next"]')
+          By.xpath('//button[text() = "Import"]')
         );
 
         await fieldsNextButton.click();

--- a/test/uiSetup.ts
+++ b/test/uiSetup.ts
@@ -83,7 +83,7 @@ export function uiHelperSetup(getDriver: () => ThenableWebDriver) {
 
     async advanceToFieldStepAndFinish() {
       const previewNextButton = await getDriver().findElement(
-        By.xpath('//button[text() = "Next"]')
+        By.xpath('//button[text() = "Choose columns"]')
       );
 
       await previewNextButton.click();
@@ -115,7 +115,7 @@ export function uiHelperSetup(getDriver: () => ThenableWebDriver) {
       await assignButton.click();
 
       const fieldsNextButton = await getDriver().findElement(
-        By.xpath('//button[text() = "Next"]')
+        By.xpath('//button[text() = "Import"]')
       );
 
       await fieldsNextButton.click();


### PR DESCRIPTION
I've been using this library for while now and I'am still very happy with it 👍 

During use of the library I found that users are guided better if the next buttons of the import steps indicate what is going to happen next instead of a generic "Next" label.  

I implemented this in a fork and have been using it successfully for a while. I believe the improvement is worth upstreaming, see also the screenshots below.

## Implementation

Overall this is a pretty minor change. I just added `nextButton` fields to the individual steps and removed the `nextButton` field in the `general` localizations. Note that this will require a change on update for library users that use a custom locale. I'm not sure if you consider that acceptable, if not we can solve this by using the alternative approach outlined below.

## Alternatives

We could make the `nextButton` fields in the individual steps optional and keep the `nextButton` field `general` as a fallback. This would keep the behavior as it is currently by default, but allow customization of the next buttons for each step by modifying the locale.

## Comparison

### Current State

![Screen Shot 2022-03-16 at 15 01 39](https://user-images.githubusercontent.com/1938293/158608500-4fea7aa1-2f81-4dc5-810f-e0c384488e24.png)

### This PR

![Screen Shot 2022-03-16 at 15 02 01](https://user-images.githubusercontent.com/1938293/158609472-b310fbae-7ee0-4f74-82cd-6334e5522cf1.png)

