### PR TITLE
Update to @use-gesture/react + collaterals

### DIFF
--- a/demo-sandbox/yarn.lock
+++ b/demo-sandbox/yarn.lock
@@ -45,10 +45,10 @@ prop-types@^15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-react-csv-importer@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/react-csv-importer/-/react-csv-importer-0.6.0.tgz#3ccee3538f0d1ac44296657713adbb3f49a61933"
-  integrity sha512-8VHyXnv/5jwKj2eHtncY6YV3moHNSW/OxxAGyqgy4vbkHCPSc2hPnNFsOOiZgMrRoB1xhEvD14LchnE+IoB6NQ==
+react-csv-importer@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-csv-importer/-/react-csv-importer-0.7.0.tgz#186ebfeb88388d957b319ce24a384dbfe5211062"
+  integrity sha512-eDo3b5PpMV6KAkJ+zEZXc26sgfAjTur1zfY/nJ9wPbAS9yUzw8pp6CJdfx+qmimrf3Q4yj54mfXPLs/IhntpJQ==
   dependencies:
     papaparse "^5.3.0"
     react-dropzone "^11.0.3"

--- a/package.json
+++ b/package.json
@@ -106,8 +106,8 @@
     "react-dom": "^16.8.0 || ^17.0.0"
   },
   "dependencies": {
+    "@use-gesture/react": "^10.2.11",
     "papaparse": "^5.3.0",
-    "react-dropzone": "^11.0.3",
-    "react-use-gesture": "^7.0.16"
+    "react-dropzone": "^12.0.5"
   }
 }

--- a/src/components/fields-step/ColumnDragSourceArea.tsx
+++ b/src/components/fields-step/ColumnDragSourceArea.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from 'react';
-import { useDrag } from 'react-use-gesture';
+import { useDrag } from '@use-gesture/react';
 
 import { FieldAssignmentMap } from '../../parser';
 import { Column } from './ColumnPreview';
@@ -47,7 +47,10 @@ const SourceBox: React.FC<{
 
   return (
     <div className="CSVImporter_ColumnDragSourceArea__box">
-      <div {...(isAssigned ? {} : eventHandlers)}>
+      <div
+        {...(isAssigned ? {} : eventHandlers)}
+        style={{ touchAction: 'none' }}
+      >
         <ColumnDragCard
           column={column}
           isAssigned={isAssigned}

--- a/src/components/fields-step/ColumnDragTargetArea.tsx
+++ b/src/components/fields-step/ColumnDragTargetArea.tsx
@@ -1,5 +1,5 @@
-import React, { useMemo, useEffect, useRef } from 'react';
-import { useDrag } from 'react-use-gesture';
+import React, { useMemo, useRef } from 'react';
+import { useDrag } from '@use-gesture/react';
 
 import { FieldAssignmentMap } from '../../parser';
 import { Column } from './ColumnPreview';
@@ -36,47 +36,9 @@ const TargetBox: React.FC<{
   onAssign,
   onUnassign
 }) => {
-  // wrap in ref to avoid re-triggering effect
-  const onHoverRef = useRef(onHover);
-  onHoverRef.current = onHover;
-
   // respond to hover events when there is active mouse drag happening
   // (not keyboard-emulated one)
   const containerRef = useRef<HTMLDivElement>(null);
-  const isHoveredRef = useRef(false); // simple tracking of current hover state to avoid spamming onHover (not for display)
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!dragState || !dragState.pointerStartInfo || !container) {
-      return;
-    }
-
-    // measure the current scroll-independent position
-    const rect = container.getBoundingClientRect();
-    const minX = rect.x;
-    const maxX = rect.x + rect.width;
-    const minY = rect.y;
-    const maxY = rect.y + rect.height;
-
-    // listen for pointer movement (mouse or touch) and detect hover
-    const listeners = dragState.updateListeners;
-    const listenerName = `field:${field.name}`;
-
-    listeners[listenerName] = (xy: number[]) => {
-      const isInBounds =
-        xy[0] >= minX && xy[0] < maxX && xy[1] >= minY && xy[1] < maxY;
-
-      if (isInBounds !== isHoveredRef.current) {
-        // cannot use local var for isHovered state because the effect re-triggers after this
-        isHoveredRef.current = isInBounds;
-        onHoverRef.current(field.name, isInBounds);
-      }
-    };
-
-    // cleanup
-    return () => {
-      delete listeners[listenerName];
-    };
-  }, [dragState, field.name]);
 
   // if this field is the current highlighted drop target,
   // get the originating column data for display
@@ -137,6 +99,8 @@ const TargetBox: React.FC<{
           : l10n.getDragTargetRequiredCaption(field.label)
       }
       ref={containerRef}
+      onPointerEnter={() => onHover(field.name, true)}
+      onPointerLeave={() => onHover(field.name, false)}
     >
       <div className="CSVImporter_ColumnDragTargetArea__boxLabel" aria-hidden>
         {field.label}
@@ -153,10 +117,12 @@ const TargetBox: React.FC<{
           </div>
         )}
 
-        <div {...dragStartHandlers}>{valueContents}</div>
+        <div {...dragStartHandlers} style={{ touchAction: 'none' }}>
+          {valueContents}
+        </div>
 
         {/* tab order after column contents */}
-        {dragState && !dragState.pointerStartInfo ? (
+        {dragState && !dragState.pointerStartClone ? (
           <div className="CSVImporter_ColumnDragTargetArea__boxValueAction">
             <IconButton
               label={l10n.getDragTargetAssignTooltip(dragState.column.code)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2422,6 +2422,18 @@
   resolved "https://registry.yarnpkg.com/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz#aa58042711d6e3275dd37dc597e5d31e8c290a44"
   integrity sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==
 
+"@use-gesture/core@10.2.11":
+  version "10.2.11"
+  resolved "https://registry.yarnpkg.com/@use-gesture/core/-/core-10.2.11.tgz#914c36f190bcf452500d11a11fc294fe56e5dc2f"
+  integrity sha512-5YeVrT9prf9UeaAO+2fIuiKdZ01uVBvVsjG79berGZPTHVkz01eFX2ODWJG05uQTqmRw6olz1J80yt6qcGPdvA==
+
+"@use-gesture/react@^10.2.11":
+  version "10.2.11"
+  resolved "https://registry.yarnpkg.com/@use-gesture/react/-/react-10.2.11.tgz#f23776050aeaee3b18f80df9cd2b765229bbfa66"
+  integrity sha512-yATjHv6ZNe9Jar1YtJvcb6KxwpcGGW/X8FEUY6xo2mDxHkP7dCsnhZZm7I+giGlrJKBMvpVBARsbUhwQP6v6nA==
+  dependencies:
+    "@use-gesture/core" "10.2.11"
+
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.9.0.tgz#bd850604b4042459a5a41cd7d338cbed695ed964"
@@ -2982,7 +2994,7 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-attr-accept@^2.0.0:
+attr-accept@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/attr-accept/-/attr-accept-2.2.2.tgz#646613809660110749e92f2c10833b70968d929b"
   integrity sha512-7prDjvt9HmqiZ0cl5CRjtS84sEyhsHP2coDkaZKRKVfCDo9s7iw7ChVmar78Gu9pC4SoR/28wFu/G5JJhTnqEg==
@@ -5661,12 +5673,12 @@ file-loader@^6.0.0, file-loader@^6.1.0:
     loader-utils "^2.0.0"
     schema-utils "^2.7.1"
 
-file-selector@^0.1.12:
-  version "0.1.13"
-  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.13.tgz#5efd977ca2bca1700992df1b10e254f4e73d2df4"
-  integrity sha512-T2efCBY6Ps+jLIWdNQsmzt/UnAjKOEAlsZVdnQztg/BtAZGNL4uX1Jet9cMM8gify/x4CSudreji2HssGBNVIQ==
+file-selector@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.4.0.tgz#59ec4f27aa5baf0841e9c6385c8386bef4d18b17"
+  integrity sha512-iACCiXeMYOvZqlF1kTiYINzgepRBymz1wwjiuup9u9nayhb6g4fSwiyJ/6adli+EPwrWtpgQAh2PoS7HukEGEg==
   dependencies:
-    tslib "^2.0.1"
+    tslib "^2.0.3"
 
 file-system-cache@^1.0.5:
   version "1.0.5"
@@ -9260,6 +9272,15 @@ prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.6.0, prop-types@^15.6.1,
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
+prop-types@^15.8.1:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
 property-information@^5.0.0, property-information@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/property-information/-/property-information-5.5.0.tgz#4dc075d493061a82e2b7d096f406e076ed859943"
@@ -9513,14 +9534,14 @@ react-draggable@^4.0.3:
     classnames "^2.2.5"
     prop-types "^15.6.0"
 
-react-dropzone@^11.0.3:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-11.1.0.tgz#c225f3c53450c80fbd80954361dc039090bfc14c"
-  integrity sha512-gJT6iJadyTbevrigm6KZFaei/yNWfokzs1idumO7fXtRNPiGFDUpsQ+trHWwUO3yWOtJibpbo5tLZggjm+KV5w==
+react-dropzone@^12.0.5:
+  version "12.0.5"
+  resolved "https://registry.yarnpkg.com/react-dropzone/-/react-dropzone-12.0.5.tgz#f9b557484a8afd6267f670f96a770ddd3948838b"
+  integrity sha512-zUjZigD0VJ91CSm9T1h7ErxFReBLaa9sjS2dUL0+inb0RROZpSJTNDHPY1rrBES5V2NXhF8v0kghmaHc81BMFg==
   dependencies:
-    attr-accept "^2.0.0"
-    file-selector "^0.1.12"
-    prop-types "^15.7.2"
+    attr-accept "^2.2.2"
+    file-selector "^0.4.0"
+    prop-types "^15.8.1"
 
 react-element-to-jsx-string@^14.3.1:
   version "14.3.1"
@@ -9627,11 +9648,6 @@ react-textarea-autosize@^8.1.1:
     "@babel/runtime" "^7.10.2"
     use-composed-ref "^1.0.0"
     use-latest "^1.0.0"
-
-react-use-gesture@^7.0.16:
-  version "7.0.16"
-  resolved "https://registry.yarnpkg.com/react-use-gesture/-/react-use-gesture-7.0.16.tgz#501985261ef9c815a377b6ff9be6df5a85fbb54f"
-  integrity sha512-gwgX+E+WQG0T1uFVl3z8j3ZwH3QQGIgVl7VtQEC2m0IscSs668sSps4Ss3CFp3Vns8xx0j9TVK4aBXH6+YrpEg==
 
 react@^16.8.3:
   version "16.13.1"
@@ -11349,6 +11365,11 @@ tslib@^2.0.0, tslib@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
+tslib@^2.0.3:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
+  integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
Hi, I maintain @use-gesture which replaced react-use-gesture. I come from this discussion https://github.com/pmndrs/use-gesture/discussions/473.

The only line you need for this is to add the following line to `useDrag` config:

```
{ pointer: { capture: false } }
```

However, I couldn't help looking at the rest of the code and tried to bring a small contribution in order to improve performance.

Have a look and let me know.
