### PR TITLE
Update peerDependencies to include React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "webpack-dev-server": "^3.7.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^18.0.0"
   },
   "dependencies": {
     "papaparse": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "webpack-dev-server": "^3.7.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^18.0.0",
+    "react": "^16.8.0 || >=17.0.0",
     "react-dom": "^16.8.0 || ^18.0.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "peerDependencies": {
     "react": "^16.8.0 || >=17.0.0",
-    "react-dom": "^16.8.0 || ^18.0.0"
+    "react-dom": "^16.8.0 || >=17.0.0"
   },
   "dependencies": {
     "papaparse": "^5.3.0",


### PR DESCRIPTION
Running into  dependency issues when using React 18


<img width="620" alt="Screen Shot 2022-04-13 at 10 17 10 AM" src="https://user-images.githubusercontent.com/62242/163201295-06e1bf91-5796-4f5f-89b3-279abdfc7b89.png">

If I force install importing is working as expected.